### PR TITLE
Removed nightly build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: php
 php:
   - 5.6
   - 7.0
-  - nightly
 
 before_script:
   - travis_retry composer self-update


### PR DESCRIPTION
Removed it so that the build isn’t flagged as "failing". Will update once the error is found and sorted out.