### PR TITLE
Add (basic) support for Laravel 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "illuminate/support": "^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
+        "illuminate/support": "^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
         "bjeavons/zxcvbn-php": "^1.2"
     },
     "require-dev": {


### PR DESCRIPTION
Verified against the L13 upgrade guide, no breaking changes affect us. The Rule contract we implement is deprecated but still present, and Validator::extend() is unchanged.