### PR TITLE
Modernize validation rule (Ideal Laravel 13 support)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "illuminate/support": "^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
+        "illuminate/support": "^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
         "bjeavons/zxcvbn-php": "^1.2"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0",
-        "illuminate/support": "^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+        "php": "^8.1",
+        "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
         "bjeavons/zxcvbn-php": "^1.2"
     },
     "require-dev": {

--- a/src/Rules/Zxcvbn.php
+++ b/src/Rules/Zxcvbn.php
@@ -2,19 +2,20 @@
 
 namespace Olssonm\Zxcvbn\Rules;
 
-use Illuminate\Contracts\Validation\Rule;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
 use ZxcvbnPhp\Zxcvbn as ZxcvbnPhp;
 
-class Zxcvbn implements Rule
+class Zxcvbn implements ValidationRule
 {
-    private $target;
+    public const MESSAGE = 'The :attribute is not strong enough.';
+
+    private int $target;
 
     /**
      * Create a new rule instance.
-     *
-     * @return void
      */
-    public function __construct($target = 5)
+    public function __construct(int $target = 5)
     {
         $this->target = $target;
     }
@@ -25,26 +26,14 @@ class Zxcvbn implements Rule
     }
 
     /**
-     * Determine if the validation rule passes.
-     *
-     * @param  string  $attribute
-     * @param  mixed  $value
-     *
-     * @return bool
+     * Run the validation rule.
      */
-    public function passes($attribute, $value)
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         $zxcvbn = (new ZxcvbnPhp())->passwordStrength($value);
-        return ($zxcvbn['score'] >= $this->target);
-    }
 
-    /**
-     * Get the validation error message.
-     *
-     * @return string
-     */
-    public function message()
-    {
-        return 'The :attribute is not strong enough.';
+        if ($zxcvbn['score'] < $this->target) {
+            $fail(self::MESSAGE);
+        }
     }
 }

--- a/src/Rules/ZxcvbnDictionary.php
+++ b/src/Rules/ZxcvbnDictionary.php
@@ -2,17 +2,18 @@
 
 namespace Olssonm\Zxcvbn\Rules;
 
-use Illuminate\Contracts\Validation\Rule;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
 use ZxcvbnPhp\Matchers\DictionaryMatch;
 
-class ZxcvbnDictionary implements Rule
+class ZxcvbnDictionary implements ValidationRule
 {
+    public const MESSAGE = 'The :attribute is too simililar to another field.';
+
     protected array $input;
 
     /**
      * Create a new rule instance.
-     *
-     * @return void
      */
     public function __construct($input1 = null, $input2 = null)
     {
@@ -25,30 +26,17 @@ class ZxcvbnDictionary implements Rule
     }
 
     /**
-     * Determine if the validation rule passes.
-     *
-     * @param  string  $attribute
-     * @param  mixed  $value
-     *
-     * @return bool
+     * Run the validation rule.
      */
-    public function passes($attribute, $value)
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         $matches = DictionaryMatch::match($value, $this->input);
         $matches = array_values(array_filter($matches, function ($match) {
             return $match->dictionaryName === 'user_inputs';
         }));
 
-        return count($matches) === 0;
-    }
-
-    /**
-     * Get the validation error message.
-     *
-     * @return string
-     */
-    public function message()
-    {
-        return 'The :attribute is too simililar to another field.';
+        if (count($matches) !== 0) {
+            $fail(self::MESSAGE);
+        }
     }
 }

--- a/src/ZxcvbnServiceProvider.php
+++ b/src/ZxcvbnServiceProvider.php
@@ -2,11 +2,9 @@
 
 namespace Olssonm\Zxcvbn;
 
-use Illuminate\Contracts\Validation\Factory;
 use Illuminate\Support\ServiceProvider;
 use Olssonm\Zxcvbn\Rules\Zxcvbn;
 use Olssonm\Zxcvbn\Rules\ZxcvbnDictionary;
-use Validator;
 use ZxcvbnPhp\Zxcvbn as ZxcvbnPhp;
 
 class ZxcvbnServiceProvider extends ServiceProvider
@@ -27,9 +25,13 @@ class ZxcvbnServiceProvider extends ServiceProvider
     {
         foreach ([Zxcvbn::class, ZxcvbnDictionary::class] as $rule) {
             $this->app['validator']->extend($rule::handle(), function ($attribute, $value, $parameters) use ($rule) {
-                return (new $rule(...$parameters))->passes($attribute, $value);
-            },
-            (new $rule())->message());
+                $instance = new $rule(...$parameters);
+                $passed = true;
+                $instance->validate($attribute, $value, function () use (&$passed) {
+                    $passed = false;
+                });
+                return $passed;
+            }, $rule::MESSAGE);
         }
     }
 }


### PR DESCRIPTION
This replaces Illuminate\Contracts\Validation\Rule with Illuminate\Contracts\Validation\ValidationRule, the modern contract introduced in Laravel 10.                        
                                                            
The old Rule contract has been deprecated since Laravel 10 and will eventually be removed. This PR moves to the recommended ValidationRule contract which uses               
validate(string $attribute, mixed $value, Closure $fail): void instead of the passes() + message() pattern.                                                                  
                                                                                                                                                                             
Both usage styles keep working:                                                                                                                                              
- Object-based: new Zxcvbn(3), new ZxcvbnDictionary($username, $email)
- String-based: 'zxcvbn:3', 'zxcvbn_dictionary:foo,bar'

All 6 existing tests pass without modification.

Since ValidationRule was introduced in Laravel 10, this bumps the minimum requirements to Laravel 10+ and PHP 8.1+.